### PR TITLE
adding sample manifests

### DIFF
--- a/manifests/iscsi.pp
+++ b/manifests/iscsi.pp
@@ -1,0 +1,90 @@
+# == Define: netapp:iscsi
+#
+# Utility for provisioning a LUN 
+# 
+# 
+# ===Parameters: 
+# 
+# [*size*]
+#    The size of the LUN to be created
+# 
+# [*initiator*] 
+#    An array of initiators
+# 
+# [*ostype*]
+#    A host OS to which LUN is attached
+# 
+# [*lunid*]
+#    LUN id of the mapping
+# 
+#  [*vol_name*]
+#    The FlexVol for the LUN
+# 
+#  ==Sample usage:
+#    
+#  Make sure that there is a SVM  'vserver01' which allows iscsi data protocol
+# 
+#  node "vserver01.localdomain" {
+#    netapp::iscsi {'host_lun':
+#      size => "500mb",
+#      lunid => "1",
+#      initiator => ["iqn.1991-05.com.microsoft:cis-jump85.cis.netapp.com"],
+#      ostype => "windows"
+#    }
+#  } 
+# 
+# 
+  define netapp::iscsi  (
+    $size,
+    $lunid,
+    $initiator,
+    $ostype,
+    $svm = "vserver01",
+    $aggr = "aggr02_node01",
+    $vol_name = 'vol1_iscsi',
+    $vol_size = "1g",
+    $grouptype = "iscsi",
+    $ensure = "present",
+    $spaceres = "volume",
+    $spacereserve = "0",
+    $spaceresenabled = "false",
+    $state = "on",
+    $igroup = "iscsi_igroup_$name"
+   ) {
+
+
+
+  netapp_volume { "${vol_name}":
+    ensure => $ensure,
+    aggregate => $aggr,
+    initsize => $vol_size,
+    spaceres => $spaceres,
+    snapreserve => $snapreserve
+  }->
+  
+  netapp_lun {"/vol/${vol_name}/${name}":
+    ensure => $ensure,
+    ostype => $ostype,
+    size => $size,
+    spaceresenabled => $spaceresenabled
+  }->
+
+  netapp_iscsi { "${svm}":
+    ensure => $ensure,
+  }->
+
+  netapp_igroup { '${igroup}':
+    ensure => $ensure,
+    group_type => $grouptype,
+    members => $initiator,
+    os_type => $ostype,
+    name => $igroup
+ }->
+
+ netapp_lun_map {"/vol/${vol_name}/${name}:${lunid}":
+    ensure => $ensure,
+    initiatorgroup =>  $igroup
+    
+  }
+}
+

--- a/manifests/nfs.pp
+++ b/manifests/nfs.pp
@@ -1,0 +1,91 @@
+#  == Define: netapp:nfs
+#
+#  Utility for provisoning NFS Share
+#
+# ===Parameters:
+#
+#  [*size*]
+#   The size of the NFS Share to be created
+#
+#  [*client*]
+#   The CIDR of the clients that would be accessing the share
+#
+#  [*path*]
+#    The export path to access the share
+# 
+#  ==Sample usage:
+#
+#  Make sure there is an SVM "SVM3" exists which allows NFS data protocol 
+#
+#  node "svm3.localdomain" {
+#   netapp::nfs {"TestVol":
+#     size => "1g",
+#     client => "172.0.0.0/8",
+#     path => '/svm3testvol1'
+#   }
+#  }
+
+  define netapp::nfs  (
+    $size,
+    $client,
+    $path,
+    $svm = "svm3",
+    $svm_root = "rootdir",
+    $aggr = "aggr01_node02",
+    $exp_policy = "exp_svm3",
+    $root_policy = "default",
+    $root_policy_rule = "1",
+    $root_policy_match = "0.0.0.0/0",
+    $rule = "1",
+    $ensure = "present",
+    $spaceres = "volume",
+    $spacereserve = "0",
+    $protocol = ['nfs'],
+    $rorule = ['sys','none'],
+    $rwrule = ['sys', 'none'],
+    $superusersecurity = "none",
+    $state = "on"
+   ) {
+
+   netapp_export_policy {"${exp_policy}_${name}":
+     ensure => $ensure
+   }
+
+   netapp_export_rule { "${exp_policy}_${name}:${rule}":
+    ensure => $ensure,
+    clientmatch => $client,
+    protocol => $protocol,
+    superusersecurity => $superusersecurity,
+    rorule => $rorule,
+    rwrule => $rwrule
+   }->
+
+   netapp_export_rule { "${root_policy}:${root_policy_rule}":
+    ensure => $ensure,
+    clientmatch => $root_policy_match,
+    superusersecurity => $superusersecurity,
+    rorule => $rorule,
+    rwrule => $rwrule
+   }->
+   netapp_nfs { "${svm}":
+    ensure => $ensure,
+   }->
+
+   netapp_volume { "${svm_root}":
+    ensure => $ensure,
+    exportpolicy => $root_policy,
+   }->
+
+   netapp_volume { "nfs_${name}":
+    ensure => $ensure,
+    aggregate => $aggr,
+    initsize => $size,
+    exportpolicy => "$exp_policy_$name",
+    spaceres => $spaceres,
+    junctionpath => $path,
+    snapreserve => $snapreserve
+   }
+
+}
+
+

--- a/manifests/svm.pp
+++ b/manifests/svm.pp
@@ -1,0 +1,110 @@
+# ==Define: netapp:svm
+#
+# Utility for creating a SVM and corresponding LIFs
+#
+# === Parameters:
+#
+# [*allowedprotos*]
+#    The data protocols allowed by the SVM (E.g. ["iscsi","nfs"]
+#
+# [*address_mgmt*]
+#    The IP address for management LIF
+#
+# [*mask_mgmt*]
+#    The netmask of IP address for management LIF
+# 
+# [*address_data*]
+#    The IP address for data LIF
+#
+# [*mask_data*]
+#    The netmask of IP address for data LIF
+# 
+# [*homenode*] 
+#    Node in the cluster acting as home node for the LIF
+#  
+# [*homeport*] 
+#    Port of node in the cluster acting as home port for the LIF
+#
+# [*aggr*]
+#     Name of the aggregate to be created
+#
+# [*aggrlist*]
+#     aggregate list for the SVM
+#
+# === Sample usage
+#   
+#  Some variables need to be adjusted according to your environment.
+#   
+#     node "puppet-dev" {
+#       netapp::svm {"svm_test":
+#         allowedprotos => ["iscsi"],
+#         address_mgmt => "172.21.11.132",
+#         mask_mgmt => "255.255.255.0",
+#         address_data => "172.21.11.133",
+#         mask_data => "255.255.255.0",
+#        }
+#     }
+#   
+#   
+  define netapp::svm  (
+    $allowedprotos,
+    $address_mgmt,
+    $mask_mgmt,
+    $address_data,
+    $mask_data,
+    $homenode = "puppet-dev-01",
+    $homeport = "e0c",
+    $aggr = "aggr01_node02",
+    $aggrlist = ["aggr01_node02"],
+    $firewallpolicy_mgmt = "mgmt",
+    $firewallpolicy_data = "data",
+    $svm_root = "rootdir",
+    $rootvol = "rootdir",
+    $role = "data",
+    $status = "up",
+    $failoverpolicy = "disabled"
+   ) {
+
+
+#Creates SVM 
+   netapp_vserver {"${name}":
+     ensure => $ensure,
+     rootvol => $rootvol,
+     rootvolaggr => $aggr,
+     aggregatelist => $aggrlist,
+     allowedprotos => $allowedprotos    
+   }->
+
+
+#Creates Management LIF
+   netapp_lif  { "${name}_mgmt":
+     ensure => $ensure,
+     vserver => $name,
+     role => $role,
+     administrativestatus => $status,
+     address => $address_mgmt,
+     homenode => $homenode,
+     homeport => $homeport,
+     netmask => $mask_data,
+     failoverpolicy => $failoverpolicy,
+     firewallpolicy => $firewallpolicy_mgmt
+   }->
+
+#Creates Data LIF
+   netapp_lif  { "${name}_data":
+     ensure => $ensure,
+     vserver => $name,
+     role => $role,
+     administrativestatus => $status,
+     dataprotocols => $allowedprotos,
+     address => $address_data,
+     homenode => $homenode,
+     homeport => $homeport,
+     netmask => $mask_data,
+     failoverpolicy => $failoverpolicy,
+     firewallpolicy => $firewallpolicy_data
+   }
+
+}
+
+


### PR DESCRIPTION
To demonstrate the usage of the module, we create three sample defined resource types which act as templates for common storage provisioning operations.  These defined resource types encapsulate the necessary resources along with their attributes for performing a particular operation.
-          nfs.pp : A defined resource type for provisioning an NFS share
-          iscsi.pp: A defined resource type for provisioning a iSCSI LUN
-          svm.pp :  A defined resource type for creating a SVM and LIFs(management and data)
